### PR TITLE
add jwt payload typing

### DIFF
--- a/src/auth/strategies/at.strategy.ts
+++ b/src/auth/strategies/at.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { JwtPayload } from '../types';
 
 @Injectable()
 export class AtStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -12,7 +13,7 @@ export class AtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  validate(payload: any) {
+  validate(payload: JwtPayload) {
     return payload;
   }
 }

--- a/src/auth/strategies/rt.strategy.ts
+++ b/src/auth/strategies/rt.strategy.ts
@@ -3,6 +3,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { JwtPayload, JwtPayloadWithRt } from '../types';
 
 @Injectable()
 export class RtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
@@ -14,7 +15,7 @@ export class RtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
     });
   }
 
-  validate(req: Request, payload: any) {
+  validate(req: Request, payload: JwtPayload): JwtPayloadWithRt {
     const refreshToken = req.get('authorization').replace('Bearer', '').trim();
     return {
       ...payload,

--- a/src/auth/types/index.ts
+++ b/src/auth/types/index.ts
@@ -1,1 +1,3 @@
 export * from './tokens.type';
+export * from './jwtPayload.type';
+export * from './jwtPayloadWithRt.type';

--- a/src/auth/types/jwtPayload.type.ts
+++ b/src/auth/types/jwtPayload.type.ts
@@ -1,0 +1,4 @@
+export type JwtPayload = {
+  email: string;
+  sub: number;
+};

--- a/src/auth/types/jwtPayloadWithRt.type.ts
+++ b/src/auth/types/jwtPayloadWithRt.type.ts
@@ -1,0 +1,3 @@
+import { JwtPayload } from '.';
+
+export type JwtPayloadWithRt = JwtPayload & { refreshToken: string };

--- a/src/common/decorators/get-current-user-id.decorator.ts
+++ b/src/common/decorators/get-current-user-id.decorator.ts
@@ -1,8 +1,10 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { JwtPayload } from 'src/auth/types';
 
 export const GetCurrentUserId = createParamDecorator(
-  (data: undefined, context: ExecutionContext): number => {
+  (_: undefined, context: ExecutionContext): number => {
     const request = context.switchToHttp().getRequest();
-    return request.user['sub'];
+    const user = request.user as JwtPayload;
+    return user.sub;
   },
 );

--- a/src/common/decorators/get-current-user.decorator.ts
+++ b/src/common/decorators/get-current-user.decorator.ts
@@ -1,7 +1,8 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { JwtPayloadWithRt } from 'src/auth/types/jwtPayloadWithRt.type';
 
 export const GetCurrentUser = createParamDecorator(
-  (data: string | undefined, context: ExecutionContext) => {
+  (data: keyof JwtPayloadWithRt | undefined, context: ExecutionContext) => {
     const request = context.switchToHttp().getRequest();
     if (!data) return request.user;
     return request.user[data];


### PR DESCRIPTION
Goals:

-  indtroducing types for jwt payload
-  show how we can rely more on TS and use keyof instead of string. 
-  because getTokens is used only in auth.service.ts seems better to pass whole user object and let that method handles what it needs
-  remove duplicates in code (discutable since method getTokensAndUpdateRtHash does 2 things obviously)

Since you did a lot of effort to go deep in the topic we should keep this repo clean, covered with tests, etc... because even though it is small, realy represents real world example