### PR TITLE
[fix] handle token refresh after logout

### DIFF
--- a/src/auth/strategies/rt.strategy.ts
+++ b/src/auth/strategies/rt.strategy.ts
@@ -22,6 +22,11 @@ export class RtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
       .trim();
 
     if (!refreshToken) throw new ForbiddenException('Refresh token malformed');
+    
+    if (!user.hashedRt) {
+      // if a logout has deleted the rt we should not be allowed to refresh it
+      return false;
+    }
 
     return {
       ...payload,


### PR DESCRIPTION
After a logout, making a token refresh attempt without this change would make the execution reach the auth service. That one will attempt to verify whether the RT from the headers and the RT hash in the DB match. But the RT hash from the DB was deleted on logout => 500 error